### PR TITLE
Variables in place for cache_domains.json and services downloaded from uklans/cache_domains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 MAINTAINER SteamCache.Net Team <team@steamcache.net>
 
-ENV STEAMCACHE_DNS_VERSION=1 ENABLE_DNSSEC_VALIDATION=false
+ENV STEAMCACHE_DNS_VERSION=1 ENABLE_DNSSEC_VALIDATION=false GITHUB_USERNAME="uklans" GITHUB_BRANCH="master"
 
 RUN	apk update && apk add			\
 		bind	\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 MAINTAINER SteamCache.Net Team <team@steamcache.net>
 
-ENV STEAMCACHE_DNS_VERSION=1 ENABLE_DNSSEC_VALIDATION=false GITHUB_USERNAME="uklans" GITHUB_BRANCH="master"
+ENV STEAMCACHE_DNS_VERSION=1 ENABLE_DNSSEC_VALIDATION=false
 
 RUN	apk update && apk add			\
 		bind	\

--- a/overlay/scripts/bootstrap.sh
+++ b/overlay/scripts/bootstrap.sh
@@ -6,6 +6,7 @@ ZONEPATH="/etc/bind/cache/"
 ZONETEMPLATE="/etc/bind/cache/zone.tmpl"
 CACHECONF="/etc/bind/cache.conf"
 USE_GENERIC_CACHE="${USE_GENERIC_CACHE:-false}"
+CACHE_DOMAIN="some-username-here1/cache-domains/minecraft"
 
 echo "     _                                      _                       _   "
 echo "    | |                                    | |                     | |  "
@@ -35,7 +36,7 @@ else
   fi
 fi
 
-echo "Bootstrapping DNS from https://github.com/uklans/cache-domains"
+echo "Bootstrapping DNS from https://github.com/${CACHE_DOMAIN}"
 
 if [ "$USE_GENERIC_CACHE" = "true" ]; then
     echo ""
@@ -51,7 +52,7 @@ fi
 rm -f ${CACHECONF}
 touch ${CACHECONF}
 
-curl -s -o services.json https://raw.githubusercontent.com/uklans/cache-domains/master/cache_domains.json
+curl -s -o services.json https://raw.githubusercontent.com/${CACHE_DOMAIN}/cache_domains.json
 
 cat services.json | jq -r '.cache_domains[] | .name, .domain_files[]' | while read L; do
   if ! echo ${L} | grep "\.txt" >/dev/null 2>&1 ; then

--- a/overlay/scripts/bootstrap.sh
+++ b/overlay/scripts/bootstrap.sh
@@ -6,7 +6,9 @@ ZONEPATH="/etc/bind/cache/"
 ZONETEMPLATE="/etc/bind/cache/zone.tmpl"
 CACHECONF="/etc/bind/cache.conf"
 USE_GENERIC_CACHE="${USE_GENERIC_CACHE:-false}"
-CACHE_DOMAIN="some-username-here1/cache-domains/minecraft"
+GITHUB_USERNAME="uklans"
+GITHUB_BRANCH="master"
+GITHUB="${GITHUB_USERNAME}/cache-domains/$GITHUB_BRANCH"
 
 echo "     _                                      _                       _   "
 echo "    | |                                    | |                     | |  "
@@ -36,7 +38,7 @@ else
   fi
 fi
 
-echo "Bootstrapping DNS from https://github.com/${CACHE_DOMAIN}"
+echo "Bootstrapping DNS from https://github.com/${GITHUB}"
 
 if [ "$USE_GENERIC_CACHE" = "true" ]; then
     echo ""
@@ -52,7 +54,7 @@ fi
 rm -f ${CACHECONF}
 touch ${CACHECONF}
 
-curl -s -o services.json https://raw.githubusercontent.com/${CACHE_DOMAIN}/cache_domains.json
+curl -s -o services.json https://raw.githubusercontent.com/${GITHUB}/cache_domains.json
 
 cat services.json | jq -r '.cache_domains[] | .name, .domain_files[]' | while read L; do
   if ! echo ${L} | grep "\.txt" >/dev/null 2>&1 ; then


### PR DESCRIPTION
As the title says. And what once was a modification for myself so I could test a branch for [some-username-here1/cache-domains/minecraft](https://github.com/some-username-here1/cache-domains/tree/minecraft), I thought it'd be a good idea to turn the static download location and `echo` into a variable that allows you to redirect to your own fork or branch for testing!

**EDIT:** I'll be testing this soon