### PR TITLE
Allow startup using locally stored domain information

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN	apk update && apk add			\
 		bind	\
 		bash	\
 		jq		\
-		curl	
+		curl	\
+		git
 
 COPY	overlay/ /
 
@@ -19,5 +20,7 @@ RUN	mkdir -p /var/cache/bind /var/log/named		\
 EXPOSE 53/udp
 
 WORKDIR /scripts
+
+RUN git clone https://github.com/uklans/cache-domains/ /opt/cache-domains
 
 CMD ["bash", "/scripts/bootstrap.sh"]


### PR DESCRIPTION
This allows the user to start the container with locally stored domain information.

This allows the DNS container to come up even when there is no internet access, with the use of -e USE_LOCAL_DOMAIN_DATA=true

It's possible that we could fully automate this, try downloading the file from github, if that fails then use locally stored information.

Thoughts?