### PR TITLE
Allow multiple UPSTREAM_DNS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - image: circleci/python:2-jessie
     steps:
       - setup_remote_docker:   # (2)
-          docker_layer_caching: true # (3)
+          docker_layer_caching: false # (3)
       - attach_workspace:
           at: /tmp/workspace
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - checkout
 
       - setup_remote_docker:   # (2)
-          docker_layer_caching: true # (3)
+          docker_layer_caching: false # (3)
       - run:
           name: Install goss
           command: |

--- a/overlay/hooks/entrypoint-pre.d/10_generate_config.sh
+++ b/overlay/hooks/entrypoint-pre.d/10_generate_config.sh
@@ -42,7 +42,12 @@ echo ""
 echo ""
 if ! [ -z "${UPSTREAM_DNS}" ] ; then
   echo "configuring /etc/resolv.conf to stop from looping to ourself"
-  echo "nameserver ${UPSTREAM_DNS}" > /etc/resolv.conf
+  echo "# Lancache dns config" > /etc/resolv.conf
+  for ns in $(echo $UPSTREAM_DNS | sed "s/[;]/ /g")
+  do
+      # call your procedure/other scripts here below
+      echo "nameserver $ns" >> /etc/resolv.conf
+  done
 fi
 echo ""
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -20,7 +20,7 @@ case $1 in
 		shift
 	fi
     export GOSS_OPTS="$GOSS_OPTS --format junit"
-	dgoss run -e USE_GENERIC_CACHE=true -e STEAMCACHE_IP=127.0.0.2 -e LANCACHE_IP=127.0.0.1 $@ lancachenet/lancache-dns:goss-test > reports/goss/report.xml
+	dgoss run -e USE_GENERIC_CACHE=true -e STEAMCACHE_IP=127.0.0.2 -e LANCACHE_IP=127.0.0.1 -e UPSTREAM_DNS="8.8.8.8; 1.1.1.1" $@ lancachenet/lancache-dns:goss-test > reports/goss/report.xml
 	#store result for exit code
 	RESULT=$?
 	#delete the junk that goss currently outputs :(
@@ -34,7 +34,7 @@ case $1 in
 		KEEPIMAGE=true
 		shift
 	fi
-	dgoss edit -e USE_GENERIC_CACHE=true -e STEAMCACHE_IP=127.0.0.2 -e LANCACHE_IP=127.0.0.1 $@ lancachenet/lancache-dns:goss-test
+	dgoss edit -e USE_GENERIC_CACHE=true -e STEAMCACHE_IP=127.0.0.2 -e LANCACHE_IP=127.0.0.1 -e UPSTREAM_DNS="8.8.8.8; 1.1.1.1" $@ lancachenet/lancache-dns:goss-test
 	RESULT=$?
     ;;
   *)
@@ -42,7 +42,7 @@ case $1 in
 		KEEPIMAGE=true
 		shift
 	fi
-	dgoss run -e USE_GENERIC_CACHE=true -e STEAMCACHE_IP=127.0.0.2 -e LANCACHE_IP=127.0.0.1 $@ lancachenet/lancache-dns:goss-test
+	dgoss run -e USE_GENERIC_CACHE=true -e STEAMCACHE_IP=127.0.0.2 -e LANCACHE_IP=127.0.0.1 -e UPSTREAM_DNS="8.8.8.8; 1.1.1.1" $@ lancachenet/lancache-dns:goss-test
 	RESULT=$?
     ;;
 esac


### PR DESCRIPTION
Allow setting multiple UPSTREAM_DNS using UPSTREAM_DNS="8.8.8.8; 1.1.1.1"

Does not allow custom ports at this point in time due to limitations in resolv.conf