### PR TITLE
add the ability to use custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ you have a DNS server on 1.2.3.4, the command argument would be `-e UPSTREAM_DNS
 
 Should you wish a cache server to have multiple IP addresses (for example a monolithic instance tuned for steam) you may specify them as a space delimited list within quotes for example: `-e STEAMCACHE_IP="1.2.3.4 5.6.7.8"`
 
+## Custom DNS Records
+
+If you would like to add custom records to your DNS server (for example additional services, ad-blocking, etc) you can do so by adding records to the `/etc/bind/cache/custom.db` file within the container. The easiest way to do this is, upon container creation, to bind a local file to a container file. To do that, the command argument would be `-v /<host path here>/custom.db:/etc/bind/cache/custom.db`
+
+Here is an example of what that `custom.db` could look like:
+```
+notes.<your domain>        A       10.0.0.230
+games.<your domain>        A       10.0.0.230
+files.<your domain>        A       10.0.0.231
+```
+
 ## Running on Startup
 
 Follow the instructions in the Docker documentation to run the container at startup.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The documentation for the LanCache.net project can be found on [our website](htt
 
 The specific documentation for this lancache-dns container is [here](http://lancache.net/docs/containers/dns/)
 
+If you have any problems after reading the documentation please see [the support page](http://lancache.net/support/) before opening a new issue on github.
+
 ## License
 
 The MIT License (MIT)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ notes.<your domain>        A       10.0.0.230
 games.<your domain>        A       10.0.0.230
 files.<your domain>        A       10.0.0.231
 ```
+For more information on the RPZ format, see the BIND9 documentation:
+https://downloads.isc.org/isc/bind9/9.14.6/doc/arm/Bv9ARM.ch05.html#zone_file
 
 ## Running on Startup
 

--- a/overlay/hooks/entrypoint-pre.d/10_generate_config.sh
+++ b/overlay/hooks/entrypoint-pre.d/10_generate_config.sh
@@ -187,7 +187,12 @@ if ! [ -z "${PASSTHRU_IPS}" ]; then
     echo ";## Additional RPZ passthroughs"                                          
     echo "32.$(reverseip $IP).rpz-client-ip      CNAME rpz-passthru." >> ${RPZ_ZONE}
   done                                                                                
-fi                                                                                      
+fi       
+
+# Ensure there is a file for BIND to see, even if it's empty
+if [ ! -f "$CUSTOM_ZONE" ]; then
+   touch $CUSTOM_ZONE;
+fi
 
 # Add line for custom domains
 echo "\$INCLUDE $CUSTOM_ZONE" >> ${RPZ_ZONE}

--- a/overlay/hooks/entrypoint-pre.d/10_generate_config.sh
+++ b/overlay/hooks/entrypoint-pre.d/10_generate_config.sh
@@ -9,6 +9,7 @@ USE_GENERIC_CACHE="${USE_GENERIC_CACHE:-false}"
 LANCACHE_DNSDOMAIN="${LANCACHE_DNSDOMAIN:-cache.lancache.net}"
 CACHE_ZONE="${ZONEPATH}$LANCACHE_DNSDOMAIN.db"
 RPZ_ZONE="${ZONEPATH}rpz.db"
+CUSTOM_ZONE="${ZONEPATH}custom.db"
 DOMAINS_PATH="/opt/cache-domains"
 UPSTREAM_DNS=${UPSTREAM_DNS:-8.8.8.8}
 
@@ -187,6 +188,9 @@ if ! [ -z "${PASSTHRU_IPS}" ]; then
     echo "32.$(reverseip $IP).rpz-client-ip      CNAME rpz-passthru." >> ${RPZ_ZONE}
   done                                                                                
 fi                                                                                      
+
+# Add line for custom domains
+echo "\$INCLUDE $CUSTOM_ZONE" >> ${RPZ_ZONE}
 
 if ! [ -z "${UPSTREAM_DNS}" ] ; then
   sed -i "s/#ENABLE_UPSTREAM_DNS#//;s/dns_ip/${UPSTREAM_DNS}/" /etc/bind/named.conf.options


### PR DESCRIPTION
With this change, it provides the user the _optional_ ability to use custom DNS overrides. This is useful for providing domain names to local caching services.

How do you use this?
1. Create your container with a special bind mount. 
I my case I used:  `-v $(pwd)/custom.db:/etc/bind/cache/custom.db`

2. Create your override file. In my case it looked like this:
```
notes.hackerlan.party           A       10.42.0.230
games.hackerlan.party           A       10.42.0.230
file-server.hackerlan.party     A       10.42.0.231
dns.hackerlan.party             A       10.42.0.232
cache.hackerlan.party           A       10.42.0.233
quake.hackerlan.party           A       10.42.0.250
```


That's it. 

Evidence it works:
```
$ dig @10.42.0.232 quake.hackerlan.party

; <<>> DiG 9.11.3-1ubuntu1.9-Ubuntu <<>> @10.42.0.232 quake.hackerlan.party
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 39338
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
; COOKIE: bb3f67a5def99fdc6b59e4965dd8dffe77db4ce618fb5ab9 (good)
;; QUESTION SECTION:
;quake.hackerlan.party.         IN      A

;; ANSWER SECTION:
quake.hackerlan.party.  5       IN      A       10.42.0.250

;; AUTHORITY SECTION:
rpz.                    60      IN      NS      localhost.

;; Query time: 4 msec
;; SERVER: 10.42.0.232#53(10.42.0.232)
;; WHEN: Sat Nov 23 00:30:05 MST 2019
;; MSG SIZE  rcvd: 120
```

Note: this is _optional_. If you do nothing different, it should continue to work as it did before. The `$INCULDE` will include a file that does not exist, as such your zone file will be unchanged.