### PR TITLE
Permit RFC1918 PTR requests to be recursed upstream

### DIFF
--- a/overlay/etc/bind/named.conf.options
+++ b/overlay/etc/bind/named.conf.options
@@ -7,6 +7,9 @@ options {
         allow-query-cache { any; };
         listen-on { any; };
         listen-on-v6 { any; };
+	
+	# Permit RFC1918 PTR lookups to be recursed upstream
+	empty-zones-enable no;
 		response-policy { zone "rpz"; };
 		rrset-order { order cyclic; };
         #ENABLE_UPSTREAM_DNS#forwarders { dns_ip; };


### PR DESCRIPTION
In order to allow lancache-dns to upstream to other internal DNS servers, it must not create empty RFC1918 zones.