### PR TITLE
Include 53/tcp in exported ports.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN	mkdir -p /var/cache/bind /var/log/named		\
 RUN git clone --depth=1 --no-single-branch https://github.com/uklans/cache-domains/ /opt/cache-domains
 
 EXPOSE 53/udp
+EXPOSE 53/tcp
 
 WORKDIR /scripts
 


### PR DESCRIPTION
Fixup for non docker-compose DNS port usage on 53/tcp