### PR TITLE
cache TTLs set to 0 with forward only

### DIFF
--- a/overlay/etc/bind/named.conf.options
+++ b/overlay/etc/bind/named.conf.options
@@ -7,6 +7,9 @@ options {
         allow-query-cache { any; };
         listen-on { any; };
         listen-on-v6 { any; };
+	max-cache-ttl 0;
+	max-ncache-ttl 0;
+	forward only;
 	
 	# Permit RFC1918 PTR lookups to be recursed upstream
 	empty-zones-enable no;


### PR DESCRIPTION
```
	max-cache-ttl 0;
	max-ncache-ttl 0;
	forward only;
```
see #114 